### PR TITLE
Fix to automatically close sidebar on menu item selection

### DIFF
--- a/src/Blazor.AdminLte/SideBar/SideBarMenuItem.razor
+++ b/src/Blazor.AdminLte/SideBar/SideBarMenuItem.razor
@@ -2,6 +2,8 @@
 @inject NavigationManager nav;
 @implements IDisposable
 @inherits BlazorState.BlazorStateComponent
+@inject IJSRuntime js  
+
 <li class="nav-item">
     <a href="@Link" class="nav-link @(State.GetState(Id).GetDescription<StyleAttribute>())" @onclick="Click" @onclick:preventDefault>
         <i class="nav-icon @Icon"></i>
@@ -24,6 +26,7 @@
     private void Click()
     {
         nav.NavigateTo(Link);
+        js.InvokeVoidAsync("closeSideBar");
     }
 
     protected override void OnInitialized()

--- a/src/Blazor.AdminLte/wwwroot/js/interop.js
+++ b/src/Blazor.AdminLte/wwwroot/js/interop.js
@@ -36,8 +36,17 @@ function addClass(el, _class) {
   //  $(el).collapse();
 }
 
-function pushMenu() {
-    $('[data-toggle="push-menu"]').pushMenu('toggle')
+function closeSideBar()
+{
+    if ($(window).width() <= 992)
+    {
+        $("body").removeClass("sidebar-open").addClass("sidebar-closed");
+    }
+}
+
+function pushMenu(action)
+{
+    $('[data-widget="pushmenu"]').PushMenu(typeof action === 'undefined' ? 'toggle' : action);
 }
 
 function toggle(el) {


### PR DESCRIPTION
#### Reference issue #34
This fix addresses the sidebar not closing when user clicks an item.
This fix will now close the sidebar after a user clicks a menu item only if the side bar is in an collapsed state. The side bar will not close if the side bar is in an expanded stated.

#### Note
Also I noticed pushMenu function had an invalid pushMenu reference, this has been updated and also updated to allow extra functionality without changing its current use.